### PR TITLE
Remove Powershell, use control-modifier-keys. Make Config work

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class KeyState extends q.DesktopApp {
       on: this.config.colorOn || '#FF0000',
       off: this.config.colorOff || '#00FF00',
     };
-    const key = this.config.key || this.keys.CapsLock.code;
+    var key = this.config.key || this.keys.CapsLock.code;
 
     try {
       var enabled = cmk.getModifierState(key);
@@ -50,10 +50,6 @@ class KeyState extends q.DesktopApp {
       });    
     } catch(err){
       KeyState.log('error');
-    }
-
-    if (cmk.getModifierState(key.toLowerCase())){
-      return new q.Signal({})
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -36,10 +36,10 @@ class KeyState extends q.DesktopApp {
       on: this.config.colorOn || '#FF0000',
       off: this.config.colorOff || '#00FF00',
     };
-    var key = this.config.key || this.keys.CapsLock.code;
+    let key = this.config.key || this.keys.CapsLock.code;
 
     try {
-      var enabled = cmk.getModifierState(key);
+      const enabled = cmk.getModifierState(key);
       KeyState.log(`${key} is ${enabled ? 'enabled' : 'disabled'}`);
       return new q.Signal({
         points: [
@@ -49,7 +49,7 @@ class KeyState extends q.DesktopApp {
         message: `${key} is ${enabled ? 'enabled' : 'disabled'}`,
       });    
     } catch(err){
-      KeyState.log('error');
+      KeyState.log(err, `error - ${err}`);
     }
   }
 


### PR DESCRIPTION
Removed dependency on node-powershell, replace with dependency on control-modifier-keys ( https://github.com/VanBerlo/control-modifier-keys ). This removed the overhead of starting up a whole Powershell every interval.

This.config() isn't available in constructor(), so I moved the stuff referring to it in to run(), per https://github.com/daskeyboard/daskeyboard-applet#readme (Constructor section)

I simplified the code a touch, too. I have this running every 100 millis on my old machine which is prone to the fans starting up only barest load, and it's not doing that anymore, for me.